### PR TITLE
Fixes #59: Added current location feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation "com.google.code.gson:gson:2.8.5"
     implementation "com.squareup.retrofit2:retrofit:2.4.0"
     implementation "com.squareup.retrofit2:converter-gson:2.4.0"
+    implementation 'org.jetbrains:annotations:15.0'
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.24.5"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ardovic.weatherappprototype">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -14,7 +16,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppThemeWithoutActionBar">
-        <activity android:name=".activities.AboutUs"></activity>
+
+
+        <activity android:name=".activities.AboutUs" />
         <activity android:name=".activities.SplashScreenActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -28,6 +32,9 @@
         <service
             android:name=".DataReaderService"
             android:exported="false" />
+        <service
+            android:name=".services.LocationService"
+            android:exported="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ardovic/weatherappprototype/activities/MainActivity.java
+++ b/app/src/main/java/com/ardovic/weatherappprototype/activities/MainActivity.java
@@ -216,7 +216,7 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
             // If user granted request then start location service to get geographic coordinates else displays last searched locations weather details
             if(grantResults[0]==PackageManager.PERMISSION_GRANTED)
             {
-                Log.v("permission","Inside if");
+                tvCityCountryName.setText("Getting location");
                 Intent intent = new Intent(MainActivity.this,LocationService.class);
                 startService(intent);
             }
@@ -224,6 +224,7 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
             {
                 cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
                 actvCityCountryName.setText(cityCountryName);
+                Toast.makeText(getApplicationContext(),"location permission is not given \nDisplaying last searched location",Toast.LENGTH_SHORT).show();
                 requestWeather();
             }
         }
@@ -577,7 +578,7 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
                 actvCityCountryName.setText(cityCountryName);
                 tvCityCountryName.setText(" ");
                 requestWeather();
-                Toast.makeText(getApplicationContext(),"location permission is not given \n Displaying last searched location",Toast.LENGTH_SHORT).show();
+                Toast.makeText(getApplicationContext(),"location permission is not given \nDisplaying last searched location",Toast.LENGTH_SHORT).show();
             }
             else if(result==1){
                 // Displaying coordinates to user
@@ -589,11 +590,8 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
             }
             else
             {
-                cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
-                actvCityCountryName.setText(cityCountryName);
                 tvCityCountryName.setText(" ");
-                requestWeather();
-                Toast.makeText(getApplicationContext(),"location is off in your device \n Displaying last searched location",Toast.LENGTH_SHORT).show();
+                Toast.makeText(getApplicationContext(),"location is off in your device \nEnter the place manually",Toast.LENGTH_SHORT).show();
             }
         }
     };

--- a/app/src/main/java/com/ardovic/weatherappprototype/activities/MainActivity.java
+++ b/app/src/main/java/com/ardovic/weatherappprototype/activities/MainActivity.java
@@ -109,6 +109,7 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
     public String lat;
     public String lon;
     public static final int MY_PERMISSIONS_REQUEST_LOCATION = 99;
+    public boolean manualSearchFlag = false;
 
     @Override
     protected void onStart() {
@@ -192,6 +193,8 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
 
             // Update the parent class's TextView
             actvCityCountryName.setText(cityCountryName);
+
+            manualSearchFlag = true;
 
             requestWeather();
             hideKeyboard();
@@ -571,27 +574,24 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
         @Override
         public void onReceive(Context context, Intent intent) {
             int result = intent.getIntExtra("result",0);
-            // if it get result 0 that means location access is not given by user. if 2 then location is off in device, otherwise we got the coordinates from service.
-            if(result==0)
-            {
-                cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
-                actvCityCountryName.setText(cityCountryName);
-                tvCityCountryName.setText(" ");
-                requestWeather();
-                Toast.makeText(getApplicationContext(),"location permission is not given \nDisplaying last searched location",Toast.LENGTH_SHORT).show();
-            }
-            else if(result==1){
-                // Displaying coordinates to user
-                lat = String.valueOf(intent.getDoubleExtra("lat",0.0));
-                lon = String.valueOf(intent.getDoubleExtra("longi",0.0));
-                requestWeatherUsingCoordinates();
-                Log.v("checkService","Inside broadcast receiver");
+            if(!manualSearchFlag) {
+                // if it get result 0 that means location access is not given by user. if 2 then location is off in device, otherwise we got the coordinates from service.
+                if (result == 0) {
+                    cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
+                    actvCityCountryName.setText(cityCountryName);
+                    tvCityCountryName.setText(" ");
+                    requestWeather();
+                    Toast.makeText(getApplicationContext(), "location permission is not given \nDisplaying last searched location", Toast.LENGTH_SHORT).show();
+                } else if (result == 1) {
+                    // Displaying coordinates to user
+                    lat = String.valueOf(intent.getDoubleExtra("lat", 0.0));
+                    lon = String.valueOf(intent.getDoubleExtra("longi", 0.0));
+                    requestWeatherUsingCoordinates();
 
-            }
-            else
-            {
-                tvCityCountryName.setText(" ");
-                Toast.makeText(getApplicationContext(),"location is off in your device \nEnter the place manually",Toast.LENGTH_SHORT).show();
+                } else {
+                    tvCityCountryName.setText(" ");
+                    Toast.makeText(getApplicationContext(), "location is off in your device \nEnter the place manually", Toast.LENGTH_SHORT).show();
+                }
             }
         }
     };

--- a/app/src/main/java/com/ardovic/weatherappprototype/activities/MainActivity.java
+++ b/app/src/main/java/com/ardovic/weatherappprototype/activities/MainActivity.java
@@ -1,11 +1,15 @@
 package com.ardovic.weatherappprototype.activities;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.LoaderManager;
+import android.content.BroadcastReceiver;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.CursorLoader;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
@@ -28,10 +32,12 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityCompat;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.ardovic.weatherappprototype.R;
 import com.ardovic.weatherappprototype.database.DatabaseHelper;
@@ -39,6 +45,7 @@ import com.ardovic.weatherappprototype.fragments.CreditFragment;
 import com.ardovic.weatherappprototype.model.IJ;
 import com.ardovic.weatherappprototype.model.retrofit.Response;
 import com.ardovic.weatherappprototype.util.ImageHelper;
+import com.ardovic.weatherappprototype.services.LocationService;
 import com.google.android.material.navigation.NavigationView;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -97,8 +104,11 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
     public final static String[] mProjection = {ID, CITY_COUNTRY_NAME};
     private static final String TAG = "MainActivity";
     private static final String CITY_ARGS = "city_weather_arg";
-    public String cityCountryName;
+    public String cityCountryName="";
     public SimpleCursorAdapter mAdapter;
+    public String lat;
+    public String lon;
+    public static final int MY_PERMISSIONS_REQUEST_LOCATION = 99;
 
     @Override
     protected void onStart() {
@@ -131,9 +141,18 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
             actionBar.setHomeAsUpIndicator(R.drawable.ic_menu_white);
         }
 
-
-        cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
-        actvCityCountryName.setText(cityCountryName);
+        // Asking for GPS permission if it's not granted by user
+        if (ActivityCompat.checkSelfPermission(getApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED || ActivityCompat.checkSelfPermission(getApplicationContext(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(MainActivity.this,
+                    new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+                    MY_PERMISSIONS_REQUEST_LOCATION);
+        }
+        else{
+            // If user has given permission then starting location service to get geographic coordinates.
+            tvCityCountryName.setText("Getting location");
+            Intent intent = new Intent(MainActivity.this, LocationService.class);
+            startService(intent);
+        }
 
 
         if (database.isOpen()) {
@@ -188,10 +207,40 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
     }
 
     @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull @org.jetbrains.annotations.NotNull String[] permissions, @NonNull @org.jetbrains.annotations.NotNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        if(requestCode == MY_PERMISSIONS_REQUEST_LOCATION)
+        {
+            Log.v("permission",grantResults[0]+" ");
+            // If user granted request then start location service to get geographic coordinates else displays last searched locations weather details
+            if(grantResults[0]==PackageManager.PERMISSION_GRANTED)
+            {
+                Log.v("permission","Inside if");
+                Intent intent = new Intent(MainActivity.this,LocationService.class);
+                startService(intent);
+            }
+            else
+            {
+                cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
+                actvCityCountryName.setText(cityCountryName);
+                requestWeather();
+            }
+        }
+    }
+
+    @Override
     protected void onStop() {
         super.onStop();
         sharedPreferences.edit().putString(CITY_COUNTRY_NAME, cityCountryName).apply();
 
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        IntentFilter filter = new IntentFilter(LocationService.ACTION);
+        LocalBroadcastManager.getInstance(this).registerReceiver(locationReceiver, filter);
     }
 
     public void createLocalCityDB() {
@@ -454,6 +503,37 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
         });
     }
 
+    private void requestWeatherUsingCoordinates() {
+        weatherApi.getWeatherUsingCoordinates(lat,lon, API_KEY).enqueue(new Callback<Response>() {
+            @SuppressLint("SetTextI18n")
+            @Override
+            public void onResponse(@NonNull Call<Response> call, @NonNull retrofit2.Response<Response> response) {
+                Response model = response.body();
+
+                if (model != null) {
+                    Log.d(TAG, model.toString());
+
+                    tvCityCountryName.setText(model.getName() + ", " + model.getSys().getCountry());
+                    tvConditionDescription.setText(model.getWeather().get(0).getMain() + " (" + (model.getWeather().get(0).getDescription() + ")"));
+                    tvTemperature.setText("" + Math.round((model.getMain().getTemp() - 273.15)) + (char) 0x00B0 + "C");
+                    tvHumidity.setText(model.getMain().getHumidity() + "%");
+                    tvPressure.setText(model.getMain().getPressure() + " hPa");
+                    tvWindSpeedDegrees.setText(model.getWind().getSpeed() + " mps, " + model.getWind().getDeg() + (char) 0x00B0);
+
+                    requestWeatherIcon(model);
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Response> call, @NonNull Throwable t) {
+                Toast.makeText(MainActivity.this, "Check internet connection or try again later", Toast.LENGTH_SHORT)
+                        .show();
+                Log.d(TAG, "Weather request error: " + t.getMessage());
+            }
+        });
+    }
+
+
     /**
      * BitmapFactory.decodeStream method needs background thread
      */
@@ -485,6 +565,38 @@ public class MainActivity extends BaseActivity implements LoaderManager.LoaderCa
             }
         });
     }
+    // listening for broadcasts from location service
+    private BroadcastReceiver locationReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            int result = intent.getIntExtra("result",0);
+            // if it get result 0 that means location access is not given by user. if 2 then location is off in device, otherwise we got the coordinates from service.
+            if(result==0)
+            {
+                cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
+                actvCityCountryName.setText(cityCountryName);
+                tvCityCountryName.setText(" ");
+                requestWeather();
+                Toast.makeText(getApplicationContext(),"location permission is not given \n Displaying last searched location",Toast.LENGTH_SHORT).show();
+            }
+            else if(result==1){
+                // Displaying coordinates to user
+                lat = String.valueOf(intent.getDoubleExtra("lat",0.0));
+                lon = String.valueOf(intent.getDoubleExtra("longi",0.0));
+                requestWeatherUsingCoordinates();
+                Log.v("checkService","Inside broadcast receiver");
+
+            }
+            else
+            {
+                cityCountryName = sharedPreferences.getString(CITY_COUNTRY_NAME, "");
+                actvCityCountryName.setText(cityCountryName);
+                tvCityCountryName.setText(" ");
+                requestWeather();
+                Toast.makeText(getApplicationContext(),"location is off in your device \n Displaying last searched location",Toast.LENGTH_SHORT).show();
+            }
+        }
+    };
 }
 
 

--- a/app/src/main/java/com/ardovic/weatherappprototype/network/WeatherApi.java
+++ b/app/src/main/java/com/ardovic/weatherappprototype/network/WeatherApi.java
@@ -22,11 +22,18 @@ public interface WeatherApi {
     String IMAGE_PATH = BASE_URL + "/img/w/{iconId}.png";
 
     String PARAM_LOCATION = "q";
+    String PARAM_LAT = "lat";
+    String PARAM_LON = "lon";
     String PARAM_APP_ID = "APPID";
 
     @GET(WEATHER_PATH)
     Call<Response> getWeather(@Query(PARAM_LOCATION) String location,
                               @Query(PARAM_APP_ID) String apiKey);
+
+    @GET(WEATHER_PATH)
+    Call<Response> getWeatherUsingCoordinates(@Query(PARAM_LAT) String lat,
+                                              @Query(PARAM_LON) String lon,
+                                              @Query(PARAM_APP_ID) String apiKey);
 
     @GET(IMAGE_PATH)
     @Streaming

--- a/app/src/main/java/com/ardovic/weatherappprototype/services/LocationService.java
+++ b/app/src/main/java/com/ardovic/weatherappprototype/services/LocationService.java
@@ -73,6 +73,7 @@ public class LocationService extends Service {
                     Intent intent = new Intent(ACTION);
                     intent.putExtra("result",0);
                     mLocalBroadcastManager.sendBroadcast(intent);
+                    stopSelf();
                 }
                 else {
                     // requesting for location updates(coordinates) using callback function
@@ -89,6 +90,7 @@ public class LocationService extends Service {
                         Intent intent = new Intent(ACTION);
                         intent.putExtra("result",2);
                         mLocalBroadcastManager.sendBroadcast(intent);
+                        stopSelf();
                     }
                 }
             }

--- a/app/src/main/java/com/ardovic/weatherappprototype/services/LocationService.java
+++ b/app/src/main/java/com/ardovic/weatherappprototype/services/LocationService.java
@@ -1,0 +1,111 @@
+package com.ardovic.weatherappprototype.services;
+
+import android.Manifest;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+public class LocationService extends Service {
+
+    private class MyLocationListnener implements LocationListener {
+        @Override
+        public void onStatusChanged(String provider, int status, Bundle extras) {
+
+        }
+
+        @Override
+        // this method calls when requestSingleUpdate method invokes
+        public void onLocationChanged(@NonNull Location location) {
+            Double lat = location.getLatitude();
+            Double longi = location.getLongitude();
+
+            // sending coordinates to main activity via a broadcast message
+            Intent intent = new Intent(ACTION);
+            intent.putExtra("result",1);
+            intent.putExtra("lat", lat);
+            intent.putExtra("longi", longi);
+            mLocalBroadcastManager.sendBroadcast(intent);
+            stopSelf();
+        }
+
+        @Override
+        public void onProviderEnabled(@NonNull String provider) {
+
+        }
+
+        @Override
+        public void onProviderDisabled(@NonNull String provider) {
+
+        }
+    }
+    private LocalBroadcastManager mLocalBroadcastManager;
+    public static final String ACTION = "com.my.app.MyCustomLocationService";
+
+    public LocationService() {
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        mLocalBroadcastManager = LocalBroadcastManager.getInstance(this);
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                // initialization of LocationManager and LocationListener
+                LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+                LocationListener locationListener = new MyLocationListnener();
+                // checking for permissions
+                if (ActivityCompat.checkSelfPermission(getApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                    // broadcasting 0 as permission is not granted by user
+                    Intent intent = new Intent(ACTION);
+                    intent.putExtra("result",0);
+                    mLocalBroadcastManager.sendBroadcast(intent);
+                }
+                else {
+                    // requesting for location updates(coordinates) using callback function
+                    if(locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER))
+                    {
+                        locationManager.requestSingleUpdate(LocationManager.NETWORK_PROVIDER,locationListener, Looper.getMainLooper());
+                    }
+                    else if(locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)){
+                        locationManager.requestSingleUpdate(LocationManager.GPS_PROVIDER, locationListener, Looper.getMainLooper());
+                    }
+                    else
+                    {
+                        // broadcasting 0 as location is off on device
+                        Intent intent = new Intent(ACTION);
+                        intent.putExtra("result",2);
+                        mLocalBroadcastManager.sendBroadcast(intent);
+                    }
+                }
+            }
+        });
+        // this will call run method of thread
+        thread.start();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        this.stopSelf();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        // TODO: Return the communication channel to the service.
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+}


### PR DESCRIPTION
## Description

When the user opens the app, the app displays weather details for the user's current location if the user has given location permission. Anyway, the user can also search for other locations like currently, they are doing.

Fixes #59 

## Type of change

### Screenshots -
**Asking for a permission at runtime -**
![WhatsApp Image 2020-11-04 at 1 40 22 AM](https://user-images.githubusercontent.com/73418895/98035598-c5301380-1e3e-11eb-81e8-1e259e7b0eec.jpeg)

**The user gave location permission so the app is fetching user's current location. While fetching location if the user wants to search weather details for other places then also user can do it because location fetching is done in background services in new thread**
![fetches location](https://user-images.githubusercontent.com/73418895/98035439-813d0e80-1e3e-11eb-80e2-15e110645c95.jpeg)

**After getting user's current location it's showing weather details for that location**
![got_location](https://user-images.githubusercontent.com/73418895/98035463-8d28d080-1e3e-11eb-8b1e-0ce620ec5d41.jpeg)

**User can also search for manual places.**
![manually serach](https://user-images.githubusercontent.com/73418895/98035422-7b472d80-1e3e-11eb-8f1f-03b65c3bbbaa.jpeg)

**After getting weather information of manually searched location**
![manually searched details got](https://user-images.githubusercontent.com/73418895/98035411-74b8b600-1e3e-11eb-802c-23a6caba2e1a.jpeg)

**If the user has not given the location permission then initially app will show the last searched place's weather details.**
![last denied](https://user-images.githubusercontent.com/73418895/98035332-594dab00-1e3e-11eb-89d7-73f161dd849b.jpeg)

## How Has This Been Tested?
On my device